### PR TITLE
Add Producto entity with image and category relations

### DIFF
--- a/src/main/java/com/uade/tpo/almacen/entity/Imagen.java
+++ b/src/main/java/com/uade/tpo/almacen/entity/Imagen.java
@@ -1,5 +1,6 @@
 package com.uade.tpo.almacen.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -14,8 +15,9 @@ public class Imagen {
     @Column
     private String imagen;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "producto_id", nullable = false)
+    @JsonBackReference
     private Producto producto;
 }
 

--- a/src/main/java/com/uade/tpo/almacen/entity/Producto.java
+++ b/src/main/java/com/uade/tpo/almacen/entity/Producto.java
@@ -1,0 +1,58 @@
+package com.uade.tpo.almacen.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Producto {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false)
+    private String nombre;
+
+    @Column(nullable = false)
+    private String descripcion;
+
+    @Column(nullable = false)
+    private String marca;
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal precio;
+
+    private String unidadMedida;
+
+    @Column(precision = 5, scale = 2)
+    private BigDecimal descuento;
+
+    private Integer stock;
+
+    private Integer stockMinimo;
+
+    private Integer ventasTotales;
+
+    private String estado;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "categoria_id", nullable = false)
+    @JsonBackReference
+    private Categoria categoria;
+
+    @OneToMany(mappedBy = "producto", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @JsonManagedReference
+    @Builder.Default
+    private List<Imagen> imagenes = new ArrayList<>();
+}
+

--- a/src/main/java/com/uade/tpo/almacen/repository/ProductoRepository.java
+++ b/src/main/java/com/uade/tpo/almacen/repository/ProductoRepository.java
@@ -2,6 +2,10 @@ package com.uade.tpo.almacen.repository;
 
 import com.uade.tpo.almacen.entity.Categoria;
 import com.uade.tpo.almacen.entity.Producto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
@@ -9,6 +13,10 @@ import java.math.BigDecimal;
 import java.util.Optional;
 
 public interface ProductoRepository extends JpaRepository<Producto, Integer>, JpaSpecificationExecutor<Producto> {
+
+    @Override
+    @EntityGraph(attributePaths = {"categoria", "imagenes"})
+    Page<Producto> findAll(Specification<Producto> spec, Pageable pageable);
 
     boolean existsByNombreAndDescripcionAndMarcaAndCategoria(
             String nombre,

--- a/src/main/java/com/uade/tpo/almacen/service/ProductoServiceImpl.java
+++ b/src/main/java/com/uade/tpo/almacen/service/ProductoServiceImpl.java
@@ -3,6 +3,7 @@ package com.uade.tpo.almacen.service;
 import com.uade.tpo.almacen.entity.Categoria;
 import com.uade.tpo.almacen.entity.HistorialPrecio;
 import com.uade.tpo.almacen.entity.Producto;
+import com.uade.tpo.almacen.entity.Imagen;
 import com.uade.tpo.almacen.entity.dto.ProductoRequest; // <- DTO en entity.dto
 import com.uade.tpo.almacen.repository.CategoriaRepository;
 import com.uade.tpo.almacen.repository.HistorialPrecioRepository;
@@ -126,6 +127,16 @@ public class ProductoServiceImpl implements ProductoService {
         p.setEstado(req.getEstado());
 
         p.setCategoria(cat);
+
+        if (req.getImagenes() != null) {
+            for (String imgStr : req.getImagenes()) {
+                Imagen img = new Imagen();
+                img.setImagen(imgStr);
+                img.setProducto(p);
+                p.getImagenes().add(img);
+            }
+        }
+
         return productoRepo.save(p);
     }
 
@@ -161,6 +172,16 @@ public class ProductoServiceImpl implements ProductoService {
             p.setCategoria(cat);
         }
 
+        if (req.getImagenes() != null) {
+            p.getImagenes().clear();
+            for (String imgStr : req.getImagenes()) {
+                Imagen img = new Imagen();
+                img.setImagen(imgStr);
+                img.setProducto(p);
+                p.getImagenes().add(img);
+            }
+        }
+
         return productoRepo.save(p);
     }
 
@@ -192,6 +213,11 @@ public class ProductoServiceImpl implements ProductoService {
             throw new IllegalArgumentException("Ya existe un producto con mismos datos en esa categoría");
         }
         p.setCategoria(cat);
+
+        if (p.getImagenes() != null) {
+            p.getImagenes().forEach(img -> img.setProducto(p));
+        }
+
         return productoRepo.save(p);
     }
 
@@ -224,6 +250,14 @@ public class ProductoServiceImpl implements ProductoService {
             Categoria cat = categoriaRepo.findById(categoriaId)
                     .orElseThrow(() -> new IllegalArgumentException("Categoria no encontrada"));
             p.setCategoria(cat);
+        }
+
+        if (cambios.getImagenes() != null) {
+            p.getImagenes().clear();
+            for (Imagen img : cambios.getImagenes()) {
+                img.setProducto(p);
+                p.getImagenes().add(img);
+            }
         }
         return productoRepo.save(p);
     }


### PR DESCRIPTION
## Summary
- create `Producto` entity with pricing, stock and relationship fields
- handle image associations when creating or updating products
- ensure repository loads category and images with products

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.uade.tpo:supermercado:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68aa535628548330b48f898fce288bd4