### PR TITLE
Add Usuario entity and update controller

### DIFF
--- a/src/main/java/com/uade/tpo/almacen/controller/UsuarioController.java
+++ b/src/main/java/com/uade/tpo/almacen/controller/UsuarioController.java
@@ -44,7 +44,7 @@ public class UsuarioController {
             this.nombre = u.getNombre();
             this.apellido = u.getApellido();
             this.rol = u.getRol();
-            this.fecha_registro = u.getFecha_registro();
+            this.fecha_registro = u.getFechaRegistro();
         }
     }
 

--- a/src/main/java/com/uade/tpo/almacen/entity/Usuario.java
+++ b/src/main/java/com/uade/tpo/almacen/entity/Usuario.java
@@ -1,0 +1,74 @@
+package com.uade.tpo.almacen.entity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import lombok.Data;
+
+@Entity
+@Data
+@Table(name = "usuarios", uniqueConstraints = {
+    @UniqueConstraint(columnNames = "username"),
+    @UniqueConstraint(columnNames = "email")
+})
+public class Usuario {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false, length = 50)
+    private String username;
+
+    @Column(nullable = false, length = 100)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(length = 50)
+    private String nombre;
+
+    @Column(length = 50)
+    private String apellido;
+
+    @Column(length = 20, nullable = false)
+    private String rol;
+
+    @Column(name = "fecha_registro", nullable = false, updatable = false)
+    private LocalDateTime fechaRegistro;
+
+    @OneToOne(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @JsonIgnore
+    private Carrito carrito;
+
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
+    private List<Direccion> direcciones = new ArrayList<>();
+
+    @OneToMany(mappedBy = "usuario", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
+    private List<Orden> ordenes = new ArrayList<>();
+
+    @PrePersist
+    public void prePersist() {
+        this.fechaRegistro = LocalDateTime.now();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce JPA entity `Usuario` with unique username and email plus relations to other models
- update `UsuarioController` to expose the new `fechaRegistro` field

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5356f35c8330b2595bb5f82cb4ce