### PR TITLE
Secure user passwords with BCrypt encoding

### DIFF
--- a/src/main/java/com/uade/tpo/almacen/controller/UsuarioController.java
+++ b/src/main/java/com/uade/tpo/almacen/controller/UsuarioController.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @RestController
 @RequestMapping("/usuarios")
@@ -26,6 +27,9 @@ public class UsuarioController {
 
     @Autowired
     private JwtUtil jwtUtil;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     // DTO para exponer solo datos seguros
     public static class UsuarioProfileDTO {
@@ -143,7 +147,7 @@ public class UsuarioController {
         }
         Usuario usuario = usuarioOpt.get();
         // Verifica la contraseña actual
-        if (!usuario.getPassword().equals(passwordChangeRequest.getContrasenaActual())) {
+        if (!passwordEncoder.matches(passwordChangeRequest.getContrasenaActual(), usuario.getPassword())) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("La contraseña actual es incorrecta.");
         }
         usuario.setPassword(passwordChangeRequest.getNuevaContrasena());
@@ -202,7 +206,7 @@ public class UsuarioController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Usuario o contraseña incorrectos.");
         }
         Usuario usuario = usuarioOpt.get();
-        if (!usuario.getPassword().equals(loginRequest.getPassword())) {
+        if (!passwordEncoder.matches(loginRequest.getPassword(), usuario.getPassword())) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Usuario o contraseña incorrectos.");
         }
         // Generar JWT

--- a/src/main/java/com/uade/tpo/almacen/security/SecurityConfig.java
+++ b/src/main/java/com/uade/tpo/almacen/security/SecurityConfig.java
@@ -8,6 +8,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class SecurityConfig {
@@ -42,5 +44,10 @@ public class SecurityConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration cfg) throws Exception {
         return cfg.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/uade/tpo/almacen/service/UsuarioService.java
+++ b/src/main/java/com/uade/tpo/almacen/service/UsuarioService.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-// import org.springframework.security.crypto.password.PasswordEncoder; // <- si usás Spring Security
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,11 +15,12 @@ import java.util.Optional;
 public class UsuarioService {
 
     private final UsuarioRepository usuarioRepository;
-    // private final PasswordEncoder passwordEncoder; // opcional
+    private final PasswordEncoder passwordEncoder;
 
-    public UsuarioService(UsuarioRepository usuarioRepository
-                      ) {
+    public UsuarioService(UsuarioRepository usuarioRepository,
+                          PasswordEncoder passwordEncoder) {
         this.usuarioRepository = usuarioRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
    
@@ -79,7 +80,7 @@ public class UsuarioService {
             throw new IllegalArgumentException("El email ya está en uso.");
         }
 
-       
+        usuario.setPassword(passwordEncoder.encode(usuario.getPassword()));
 
         return usuarioRepository.save(usuario);
     }
@@ -107,7 +108,7 @@ public class UsuarioService {
         }
 
         if (cambios.getPassword() != null && !cambios.getPassword().isBlank()) {
-            existente.setPassword(cambios.getPassword());
+            existente.setPassword(passwordEncoder.encode(cambios.getPassword()));
         }
         if (cambios.getNombre() != null) existente.setNombre(cambios.getNombre());
         if (cambios.getApellido() != null) existente.setApellido(cambios.getApellido());


### PR DESCRIPTION
## Summary
- declare BCrypt-based `PasswordEncoder` bean
- hash user passwords on creation and update
- validate logins and password changes with encoded passwords

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5358663c83309e8bb5e08dbb256f