### PR TITLE
Externalize JWT secret key configuration

### DIFF
--- a/src/main/java/com/uade/tpo/almacen/security/JwtUtil.java
+++ b/src/main/java/com/uade/tpo/almacen/security/JwtUtil.java
@@ -2,6 +2,7 @@ package com.uade.tpo.almacen.security;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
@@ -13,7 +14,8 @@ import java.util.Map;
 @Component
 public class JwtUtil {
 
-    private String SECRET_KEY = "claveSecretaSuperSegura"; // movelo a config segura
+    @Value("${jwt.secret}")
+    private String secretKey;
     private long EXPIRATION_TIME = 1000 * 60 * 60; // 1 hora
 
     // Método original
@@ -34,7 +36,7 @@ public class JwtUtil {
                 .setSubject(subject)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
-                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
     }
 
@@ -48,7 +50,7 @@ public class JwtUtil {
 
     private Claims extractAllClaims(String token) {
         return Jwts.parser()
-                .setSigningKey(SECRET_KEY)
+                .setSigningKey(secretKey)
                 .parseClaimsJws(token)
                 .getBody();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+jwt.secret=claveSecretaSuperSegura


### PR DESCRIPTION
## Summary
- add `jwt.secret` property in `application.properties`
- inject JWT secret into `JwtUtil` via `@Value`
- use injected secret for signing and verifying tokens

## Testing
- `mvn test` *(fails: Network is unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5359a2688330a6ee1f465fdcb0a8