### PR TITLE
Allow user login and registration without JWT

### DIFF
--- a/src/main/java/com/uade/tpo/almacen/security/JwtRequestFilter.java
+++ b/src/main/java/com/uade/tpo/almacen/security/JwtRequestFilter.java
@@ -26,13 +26,13 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
     // Endpoints públicos (no requieren auth)
     private static final List<String> WHITELIST = List.of(
-            "/auth/login",
-            "/auth/register",
+            "/usuarios/login",
+            "/usuarios",
             "/v3/api-docs",
             "/v3/api-docs/**",
             "/swagger-ui/**",
             "/swagger-ui.html",
-            "/producto",           
+            "/producto",
             "/producto/catalogo"
     );
 

--- a/src/main/java/com/uade/tpo/almacen/security/SecurityConfig.java
+++ b/src/main/java/com/uade/tpo/almacen/security/SecurityConfig.java
@@ -25,8 +25,8 @@ public class SecurityConfig {
             .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(
-                    "/auth/login",
-                    "/auth/register",
+                    "/usuarios/login",
+                    "/usuarios",
                     "/v3/api-docs/**",
                     "/swagger-ui/**",
                     "/producto",


### PR DESCRIPTION
## Summary
- Expose `/usuarios/login` and `/usuarios` as public routes
- Keep catalog and product endpoints accessible without authentication

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -q spring-boot:run` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aa535ad89883308f273b49cab74a56