### PR TITLE
Filtrar productos sin stock o inactivos

### DIFF
--- a/src/main/java/com/uade/tpo/almacen/controller/ProductoController.java
+++ b/src/main/java/com/uade/tpo/almacen/controller/ProductoController.java
@@ -51,11 +51,16 @@ public class ProductoController {
         Page<Producto> productos = productoService.filtrarProductos(
                 nombre, marca, categoriaId, precioMin, precioMax, PageRequest.of(pageNum, pageSize));
 
-        if (productos.isEmpty()) {
+        var list = productos.stream()
+                .filter(p -> p.getStock() > p.getStockMinimo() && "activo".equalsIgnoreCase(p.getEstado()))
+                .map(ProductoDTO::new)
+                .collect(Collectors.toList());
+
+        Page<ProductoDTO> productosDTO = new PageImpl<>(list, productos.getPageable(), list.size());
+
+        if (productosDTO.isEmpty()) {
             throw new ProductoNotFoundException("No hay productos que coincidan con los filtros");
         }
-
-        Page<ProductoDTO> productosDTO = productos.map(ProductoDTO::new);
         return ResponseEntity.ok(productosDTO);
     }
 
@@ -66,7 +71,10 @@ public class ProductoController {
         }
         Optional<Producto> result = productoService.getProductoById(id);
         if (result.isPresent()) {
-            return ResponseEntity.ok(new ProductoDTO(result.get()));
+            Producto p = result.get();
+            if (p.getStock() > p.getStockMinimo() && "activo".equalsIgnoreCase(p.getEstado())) {
+                return ResponseEntity.ok(new ProductoDTO(p));
+            }
         }
         throw new ProductoNotFoundException("No se encontró el producto con id: " + id);
     }
@@ -79,7 +87,10 @@ public class ProductoController {
         }
         Optional<Producto> result = productoService.getProductoByName(nombreProducto);
         if (result.isPresent()) {
-            return ResponseEntity.ok(new ProductoDTO(result.get()));
+            Producto p = result.get();
+            if (p.getStock() > p.getStockMinimo() && "activo".equalsIgnoreCase(p.getEstado())) {
+                return ResponseEntity.ok(new ProductoDTO(p));
+            }
         }
         throw new ProductoNotFoundException("No se encontró el producto con nombre: " + nombreProducto);
     }
@@ -94,7 +105,10 @@ public class ProductoController {
         if (categoriaOptional.isPresent()) {
             Optional<Producto> producto = productoService.getProductoByCategory(categoriaOptional.get());
             if (producto.isPresent()) {
-                return ResponseEntity.ok(new ProductoDTO(producto.get()));
+                Producto p = producto.get();
+                if (p.getStock() > p.getStockMinimo() && "activo".equalsIgnoreCase(p.getEstado())) {
+                    return ResponseEntity.ok(new ProductoDTO(p));
+                }
             }
         }
         throw new ProductoNotFoundException("No se encontró el producto con categoría: " + categoriaId);
@@ -108,7 +122,10 @@ public class ProductoController {
         }
         Optional<Producto> result = productoService.getProductoByMarca(marca);
         if (result.isPresent()) {
-            return ResponseEntity.ok(new ProductoDTO(result.get()));
+            Producto p = result.get();
+            if (p.getStock() > p.getStockMinimo() && "activo".equalsIgnoreCase(p.getEstado())) {
+                return ResponseEntity.ok(new ProductoDTO(p));
+            }
         }
         throw new ProductoNotFoundException("No se encontró el producto con marca: " + marca);
     }
@@ -134,7 +151,10 @@ public class ProductoController {
         }
 
         if (result.isPresent()) {
-            return ResponseEntity.ok(new ProductoDTO(result.get()));
+            Producto p = result.get();
+            if (p.getStock() > p.getStockMinimo() && "activo".equalsIgnoreCase(p.getEstado())) {
+                return ResponseEntity.ok(new ProductoDTO(p));
+            }
         }
         throw new ProductoNotFoundException(
                 "No se encontraron productos con precio máximo: " + precioMax + " y mínimo: " + precioMin);

--- a/src/main/java/com/uade/tpo/almacen/excepciones/ProductoNotFoundException.java
+++ b/src/main/java/com/uade/tpo/almacen/excepciones/ProductoNotFoundException.java
@@ -3,7 +3,7 @@ package com.uade.tpo.almacen.excepciones;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.http.HttpStatus;
 
-@ResponseStatus(code = HttpStatus.BAD_REQUEST, reason = "El producto no existe.")
+@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "El producto no existe.")
 public class ProductoNotFoundException extends Exception {
     
     public ProductoNotFoundException(String message) {

--- a/src/main/java/com/uade/tpo/almacen/service/ProductoServiceImpl.java
+++ b/src/main/java/com/uade/tpo/almacen/service/ProductoServiceImpl.java
@@ -46,7 +46,8 @@ public class ProductoServiceImpl implements ProductoService {
                                            Pageable pageable) {
 
         Specification<Producto> spec = Specification
-                .where(nombreLike(nombre))
+                .where(activoConStock())
+                .and(nombreLike(nombre))
                 .and(marcaLike(marca))
                 .and(categoriaIdEquals(categoriaId))
                 .and(precioMin(precioMin))
@@ -58,34 +59,39 @@ public class ProductoServiceImpl implements ProductoService {
     // ==========================
     // Finders usados por el controller
     // ==========================
+    private Optional<Producto> filtrarProducto(Optional<Producto> producto) {
+        return producto.filter(p -> p.getStock() > p.getStockMinimo()
+                && "activo".equalsIgnoreCase(p.getEstado()));
+    }
+
     @Override
     public Optional<Producto> getProductoById(int id) {
-        return productoRepo.findById(id);
+        return filtrarProducto(productoRepo.findById(id));
     }
 
     @Override
     public Optional<Producto> getProductoByName(String nombreProducto) {
-        return productoRepo.findFirstByNombreIgnoreCase(nombreProducto);
+        return filtrarProducto(productoRepo.findFirstByNombreIgnoreCase(nombreProducto));
     }
 
     @Override
     public Optional<Producto> getProductoByMarca(String marca) {
-        return productoRepo.findFirstByMarcaIgnoreCase(marca);
+        return filtrarProducto(productoRepo.findFirstByMarcaIgnoreCase(marca));
     }
 
     @Override
     public Optional<Producto> getProductoByCategory(Categoria categoria) {
-        return productoRepo.findFirstByCategoria(categoria);
+        return filtrarProducto(productoRepo.findFirstByCategoria(categoria));
     }
 
     @Override
     public Optional<Producto> getProductoByPrecioMaximo(BigDecimal precioMax) {
-        return productoRepo.findFirstByPrecioLessThanEqual(precioMax);
+        return filtrarProducto(productoRepo.findFirstByPrecioLessThanEqual(precioMax));
     }
 
     @Override
     public Optional<Producto> getProductoByPrecioMinimo(BigDecimal precioMin) {
-        return productoRepo.findFirstByPrecioGreaterThanEqual(precioMin);
+        return filtrarProducto(productoRepo.findFirstByPrecioGreaterThanEqual(precioMin));
     }
 
     @Override
@@ -94,7 +100,7 @@ public class ProductoServiceImpl implements ProductoService {
         BigDecimal min = (precioMin == null) ? BigDecimal.ZERO : precioMin;
         BigDecimal max = (precioMax == null) ? min : precioMax;
         if (max.compareTo(min) < 0) { BigDecimal t = min; min = max; max = t; }
-        return productoRepo.findFirstByPrecioBetween(min, max);
+        return filtrarProducto(productoRepo.findFirstByPrecioBetween(min, max));
     }
 
     // ==========================

--- a/src/main/java/com/uade/tpo/almacen/spec/ProductoSpecifications.java
+++ b/src/main/java/com/uade/tpo/almacen/spec/ProductoSpecifications.java
@@ -43,4 +43,11 @@ public class ProductoSpecifications {
         }
         return (root, query, cb) -> cb.lessThanOrEqualTo(root.get("precio"), max);
     }
+
+    public static Specification<Producto> activoConStock() {
+        return (root, query, cb) -> cb.and(
+                cb.equal(cb.lower(root.get("estado")), "activo"),
+                cb.greaterThan(root.get("stock"), root.get("stockMinimo"))
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Agrega Specification `activoConStock` para centralizar el filtro de stock y estado.
- ProductoService usa el nuevo filtro en consultas y getters de producto.
- ProductoController verifica stock disponible y responde 404 cuando no hay productos válidos.

## Testing
- `mvn -q -e test` *(falló: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5361895c8330af3f9ebcdcdea15a